### PR TITLE
fix: docker startup in clean repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ test-results
 .vscode
 e2e
 *.sqlite
+*.tsbuildinfo

--- a/frontend/src/pages/__tests__/RecipePage.test.tsx
+++ b/frontend/src/pages/__tests__/RecipePage.test.tsx
@@ -1,7 +1,7 @@
 import type { Ingredient, Recipe } from '@app/shared';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import RecipePage from '../RecipePage';
 import { AuthProvider } from '../../auth/AuthContext';
 


### PR DESCRIPTION
fixes: #61 

Problem was a missing import in the frontend test `RecipePage.test.tsx`. In normal dev this does not error since this import is already used in the backend and because of the monorepo structure these are also included when building the frontend. And because the `*n.tsbuildinfo` was not part of the dockerignore, when building a container using `docker` the type validation was skipped entirely since the file already existed. And since the frontend container never installs the backend deps the import is missing. Therefore the error only happened in these specific circumstances:
- no `*.tsbuildinfo` present
- in container (no backend deps)

The fix: exclude the `*.tsbuildinfo` from the container so that the type check runs and add the missing import so that the check does not fail. 